### PR TITLE
fix “canon CR3 tags” url

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ other contributors are welcome!
 
 The Canon CR3 format is mainly based on the ISO Base Media File Format (ISO/IEC 14496-12), with custom tags. Some tags contains TIFF structures (like IFDs, Makernotes...)
 
-Phil Harvey, the author of ExifTool, already identified some custom tags: [Canon CR3 tags](http://https://sno.phy.queensu.ca/~phil/exiftool/TagNames/Canon.html#uuid "Canon CR3 tags")
+Phil Harvey, the author of ExifTool, already identified some custom tags: [Canon CR3 tags](https://sno.phy.queensu.ca/~phil/exiftool/TagNames/Canon.html#uuid "Canon CR3 tags")
 
 Canon Raw v2 is described here: http://lclevy.free.fr/cr2/ and Canon CRW here: https://sno.phy.queensu.ca/~phil/exiftool/canon_raw.html
 


### PR DESCRIPTION
There was an extraneous “http://” before “https://» in “canon CR3 tags” url.